### PR TITLE
Fixed build in docker

### DIFF
--- a/match_service/Dockerfile
+++ b/match_service/Dockerfile
@@ -1,7 +1,7 @@
 
 # syntax=docker/dockerfile:1.4
 
-FROM python:3.8-alpine AS builder
+FROM python:3.10-alpine AS builder
 EXPOSE 8000
 WORKDIR /match_service
 COPY requirements.txt /match_service

--- a/match_service/requirements.txt
+++ b/match_service/requirements.txt
@@ -1,6 +1,7 @@
 Django==4.1.3
+ruamel.yaml.clib==0.2.2
 pytest-django==4.5.2
 djangorestframework==3.13.1
 pymongo[srv]==3.12.1
 djongo==1.3.6
-drf_yasg==1.21.3
+drf_yasg==1.21.4


### PR DESCRIPTION
drf_yasg needs previous version of ruamel.yaml.clib, this version is downgraded to 0.2.2