### PR TITLE
Solved service duplicity in Okteto

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,5 @@
 services:
-  web:
-    container_name: match-service
+  match-service:
     build:
       context: match_service
       target: builder


### PR DESCRIPTION
Changed name of the service to "match-service". This is caused because okteto don't call service like "container_name" attribute.