### PR TITLE
Create alternative requirements for docker

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -12,7 +12,7 @@ on:
 env:
   SECRET_KEY: 'django-insecure-8*23gd&8$quu(fy6j4$1h24##xv6#@%%d&fd+$0&63e)m4$(!@'
   DEBUG: 1
-  MONGO_URL: 'mongodb+srv://calat:1234@cluster0.i1yihyt.mongodb.net/?retryWrites=true&w=majority' # Se debe cambiar con la DB respectiva
+  MONGO_URL: 'mongodb+srv://match:MWyTtjZTs7i31rnW@match.cnh2f2f.mongodb.net/test?retryWrites=true&w=majority' # Se debe cambiar con la DB respectiva
 
 permissions:
   contents: read

--- a/match_service/Dockerfile
+++ b/match_service/Dockerfile
@@ -5,7 +5,7 @@ FROM python:3.10-alpine AS builder
 EXPOSE 8000
 WORKDIR /match_service
 COPY requirements.txt /match_service
-RUN pip3 install -r requirements.txt --no-cache-dir
+RUN pip3 install -r requirements-docker.txt --no-cache-dir
 COPY . /match_service
 ENTRYPOINT ["python3"]
 CMD ["manage.py", "runserver", "0.0.0.0:8000"]

--- a/match_service/requirements-docker.txt
+++ b/match_service/requirements-docker.txt
@@ -1,4 +1,5 @@
 Django==4.1.3
+ruamel.yaml.clib==0.2.2
 pytest-django==4.5.2
 djangorestframework==3.13.1
 django-cors-headers==3.13.0


### PR DESCRIPTION
Library ruamel it's needed for deploying in docker, but can't work with CI in Github Actions.