### PR TITLE
Retrieve only one element by url correctly

### DIFF
--- a/match_service/match_api/views.py
+++ b/match_service/match_api/views.py
@@ -61,8 +61,8 @@ class MatchViewSet(viewsets.ModelViewSet):
 
     #get url
     def get_url(self, request, pk=None):
-        queryset = Match.objects.filter(url=pk)
-        serializer_class = MatchSerializer(queryset, many=True)
+        queryset = Match.objects.filter(url=pk).first()
+        serializer_class = MatchSerializer(queryset)
         return Response(serializer_class.data)
 
     # create


### PR DESCRIPTION
When function is called, it returns multiple elements or even an exception.